### PR TITLE
LUA API: force reconnect when wrk.thread.addr is set

### DIFF
--- a/scripts/multi-server.lua
+++ b/scripts/multi-server.lua
@@ -1,0 +1,145 @@
+-- This script extends wrk2 to handle multiple server addresses, and multiple
+-- paths on each server.
+
+local threads = {}
+local counter = 1
+
+-- Global context
+
+function setup(thread)
+    table.insert(threads, thread)
+    thread:set("id",counter)
+    counter = counter +1
+    math.randomseed(os.time())
+    math.random(); math.random(); math.random()
+end
+
+-- Thread context
+
+function thread_next_server()
+    idx = math.random(#reqs)
+    local next_addr = string.format("%s", addrs[idx])
+    if curr_addr ~= "" and next_addr ~= curr_addr then
+        wrk.thread.addr = addrs[idx]
+    end
+    curr_addr = next_addr
+end
+
+
+function init(args)
+    urls = ""
+    counts = ""
+    reqs  = {""}
+    c_resps = 0
+    c_requs = 0
+    addrs = {}
+    curr_addr = ""
+    idx = 0
+
+    if 2 > #args then
+        --print("Usage: wrk <URL> <pattern> <count>")
+        os.exit(1)
+    end
+
+    -- the dash ("-") is magic in lua, so we need to escape it.
+    local match = string.gsub(args[1], '-', '%%%-')
+    local count = tonumber(args[2],10)
+    local p = wrk.port
+    if not p then p="" else p=":" .. p end
+
+    local paths={}
+    for i=3, #args, 1 do
+        if "/" == args[i]:sub(1,1) then
+            paths[i-2] = args[i]
+        else
+            paths[i-2] = "/" .. args[i]
+        end
+    end
+    if 0 == #paths then
+        paths[1] = "/"
+    end
+
+    for i=1, count, 1 do
+        local repl = string.gsub(match, "-[0-9]+$", string.format("-%d",i))
+        local host = string.gsub(wrk.host, match, repl)
+        for j=1, #paths, 1 do
+            local idx = (i-1) * #paths  + j
+            for k, v in ipairs(wrk.lookup(host, wrk.port or "http")) do
+                addrs[idx] = v; break
+            end
+            reqs[idx] = string.format(
+                    "GET %s HTTP/1.1\r\n"
+                    .. "Host:%s%s\r\n\r\n",
+                        paths[j], host, p)
+            urls = string.format("%s,(%s) %s://%s%s%s",
+                        urls, addrs[idx], wrk.scheme, host, p, paths[j])
+        end
+    end
+
+    urls = urls .. ","
+    thread_next_server()
+end
+
+
+function request()
+    local ret = reqs[idx]
+
+    if counts == "" then
+        counts = tostring(idx)
+    else
+        counts = string.format("%s,%s", counts, tostring(idx))
+    end
+
+    c_requs = c_requs + 1
+    return ret
+end
+
+
+function response(status, headers, body)
+    c_resps = c_resps + 1
+    thread_next_server()
+end
+
+-- Global context
+
+function done(summary, latency, requests)
+    print(string.format("Total Requests: %d", summary.requests))
+    print(string.format("HTTP errors: %d", summary.errors.status))
+    print(string.format("Requests timed out: %d", summary.errors.timeout)) 
+    print(string.format("Bytes received: %d", summary.bytes))
+    print(string.format("Socket connect errors: %d", summary.errors.connect))
+    print(string.format("Socket read errors: %d", summary.errors.read))
+    print(string.format("Socket write errors: %d", summary.errors.write))
+
+    -- generate table of URLs from first thread's string (all threads use same list)
+    local urls = {}
+    local c_requs = 0
+    local c_resps = 0
+    t = unpack(threads,1,2)
+    t:get("urls"):gsub("([^,]+),", function(u) table.insert(urls, u) end)
+
+    local counts = {}
+    for i=1, #urls, 1 do
+        counts[i] = 0
+    end
+
+    -- fetch url call counts of individual threads
+    local c = t:get("counts")
+    c = c .. ","
+    for i, t in ipairs(threads) do
+        c:gsub("([0-9]+),", function(s)
+                                i = tonumber(s)
+                                counts[i] = counts[i] + 1
+                             end)
+        c_requs = c_requs + t:get("c_requs")
+        c_resps = c_resps + t:get("c_resps")
+    end
+
+    print(string.format("total requests issued:%d, responses received within runtime:%d", c_requs, c_resps))
+
+    print("\nURL call count")
+    for i=1, #urls, 1 do
+        print(string.format("%s %d", urls[i], counts[i]))
+    end
+
+end

--- a/src/script.c
+++ b/src/script.c
@@ -415,7 +415,8 @@ static int script_thread_index(lua_State *L) {
     if (!strcmp("get",  key)) lua_pushcfunction(L, script_thread_get);
     if (!strcmp("set",  key)) lua_pushcfunction(L, script_thread_set);
     if (!strcmp("stop", key)) lua_pushcfunction(L, script_thread_stop);
-    if (!strcmp("addr", key)) script_addr_clone(L, t->addr);
+    if (!strcmp("addr", key)) { script_addr_clone(L, t->addr);
+                                if (t->reconnect_all) t->reconnect_all(t); }
     return 1;
 }
 

--- a/src/script.c
+++ b/src/script.c
@@ -415,8 +415,7 @@ static int script_thread_index(lua_State *L) {
     if (!strcmp("get",  key)) lua_pushcfunction(L, script_thread_get);
     if (!strcmp("set",  key)) lua_pushcfunction(L, script_thread_set);
     if (!strcmp("stop", key)) lua_pushcfunction(L, script_thread_stop);
-    if (!strcmp("addr", key)) { script_addr_clone(L, t->addr);
-                                if (t->reconnect_all) t->reconnect_all(t); }
+    if (!strcmp("addr", key)) script_addr_clone(L, t->addr);
     return 1;
 }
 
@@ -428,6 +427,7 @@ static int script_thread_newindex(lua_State *L) {
         if (t->addr) zfree(t->addr->ai_addr);
         t->addr = zrealloc(t->addr, sizeof(*addr));
         script_addr_copy(addr, t->addr);
+        if (t->reconnect_all) t->reconnect_all(t);
     } else {
         luaL_error(L, "cannot set '%s' on thread", luaL_typename(L, -1));
     }

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -304,7 +304,7 @@ static void thread_reconnect_all(void *_t) {
     thread * t = (thread*)_t;
     connection *c = t->cs;
     for (uint64_t i = 0; i < t->connections; i++, c++) {
-        if (c && 0 <= c->fd) reconnect_socket(t, c);
+        if (c && 0 < c->fd) reconnect_socket(t, c);
     }
 }
 

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -85,6 +85,8 @@ int main(int argc, char **argv) {
         exit(1);
     }
 
+    printf("This is wrk2, w/ thread address setting support.\n");
+
     char *schema  = copy_url_part(url, &parts, UF_SCHEMA);
     char *host    = copy_url_part(url, &parts, UF_HOST);
     char *port    = copy_url_part(url, &parts, UF_PORT);
@@ -132,8 +134,7 @@ int main(int argc, char **argv) {
         t->connections = connections;
         t->throughput = throughput;
         t->stop_at     = stop_at;
-        t->reconnect_all = &thread_reconnect_all;
-        t->cs = NULL;
+        t->reconnect_all = NULL;
 
         t->L = script_create(cfg.script, url, headers);
         script_init(L, t, argc - optind, &argv[optind]);
@@ -284,6 +285,7 @@ void *thread_main(void *arg) {
         // Stagger connects 5 msec apart within thread:
         aeCreateTimeEvent(loop, i * 5, delayed_initial_connect, c, NULL);
     }
+    thread->reconnect_all = &thread_reconnect_all;
 
     uint64_t calibrate_delay = CALIBRATE_DELAY_MS + (thread->connections * 5);
     uint64_t timeout_delay = TIMEOUT_INTERVAL_MS + (thread->connections * 5);

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -30,6 +30,7 @@ typedef struct {
     aeEventLoop *loop;
     struct addrinfo *addr;
     uint64_t connections;
+    void (*reconnect_all)(void*);
     int interval;
     uint64_t stop_at;
     uint64_t complete;


### PR DESCRIPTION
This change forces a reconnect of all connections of a thread
when wrk.thread.addr is set from a LUA script.

wrk.thread.addr has always been writeable from LUA, but the
actual socket connection was never updated in wrk'c C code.
This change enables LUA scripts to connect to multiple servers,
extending the feature set of wrk.

The PR also adds scripts/multi-server.lua to illustrate how the new
feature can be used to access multiple paths on multiple servers
from a single thread. 