### PR TITLE
scripting: per-thread "teardown" callback, init all threads before start, set up endpoints once instead of per thread

### DIFF
--- a/SCRIPTING
+++ b/SCRIPTING
@@ -52,7 +52,7 @@ Setup
   threads have been initialized but not yet started.
 
   setup() is called once for each thread and receives a userdata object
-  representing the thread.
+  representing the thread. setup() is called in the global LUA context.
 
     thread.addr             - get or set the thread's server address
     thread:get(name)        - get the value of a global in the thread's env
@@ -64,6 +64,9 @@ Setup
   thread is running.
 
 Running
+
+  The following functions are called in a privte per-thread LUA context. Each
+  context corresponds to an entry in the 'thread' table passed to setup().
 
   function init(args)
   function request()
@@ -87,9 +90,12 @@ Running
   body to be passed instead of the actual body. The option is useful for
   benchmarking endpoints which pass large response bodies.
 
+  teardown() is called without arguments after the run concluded.
 Done
 
   function done(summary, latency, requests)
+
+  done() is called in the global LUA context.
 
   The done() function receives a table containing result data, and two
   statistics objects representing the per-request latency and per-thread

--- a/SCRIPTING
+++ b/SCRIPTING
@@ -59,9 +59,9 @@ Setup
     thread:set(name, value) - set the value of a global in the thread's env
     thread:stop()           - stop the thread
 
-  Only boolean, nil, number, and string values or tables of the same may be
-  transfered via get()/set() and thread:stop() can only be called while the
-  thread is running.
+  Only boolean, nil, number, wrk.addr, and string values or tables of the same
+  may be transfered via get()/set() and thread:stop() can only be called while
+  the thread is running.
 
 Running
 

--- a/docker/Dockerfile.benchmark-container-prometheus-export
+++ b/docker/Dockerfile.benchmark-container-prometheus-export
@@ -23,6 +23,8 @@ COPY --from=builder /usr/local/lib/lua/ /usr/local/lib/lua/
 COPY --from=builder /usr/local/share/lua/ /usr/local/share/lua/
 COPY --from=builder /usr/src/wrk2-cache-stresser/scripts/multiple-endpoints-prometheus-metrics.lua /usr/local/bin/
 
+RUN mkdir /tmpfs
+
 COPY ./docker/prometheus-export-wrapper /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/prometheus-export-wrapper"]

--- a/docker/prometheus-export-wrapper
+++ b/docker/prometheus-export-wrapper
@@ -168,7 +168,6 @@ prometheus_pusher() {
     local req_rps="$2"
     local duration="$3"
     local curl_pgw="$4"
-    local start_ts="$5"
 
     local cpuinfo=$(get_cpuinfo)
     local threads=$(get_cpuinfo | grep '{info="threads"}' | sed 's/.*} //')
@@ -179,32 +178,64 @@ prometheus_pusher() {
     local meminfo=$(get_meminfo)
 
     local iter=0
+    local init=1
+
+    local start_ts=""
+    local last_load_report=$(date +%s)
 
     while [ ! -f "benchmark-end.txt" ] ; do
-        mcount=$(ls -1 thread-*_seq-${iter}.txt 2>/dev/null | wc -l)
-
-        [ $mcount -lt $num_threads ] && {
-            sleep 0.01 # yield CPU
-            continue; }
-
         now=$(date +%s)
-        runtime=$(($now - $start_ts))
-        progress=$(($runtime * 100 / $duration))
-        [ $progress -gt 100 ] && progress=100
-
-        # update every 10s
-        if [ $((runtime % 10)) -eq 0 ] ; then
+        # update load stats every 10s
+        if [ $(($now - $last_load_report)) -ge 10 ] ; then
             cpuclock=$(get_cpuclock)
             loadavg=$(get_loadavg "$cores" "$threads")
             meminfo=$(get_meminfo)
-        fi
-
-        # runtime info
-        cat << EOF | $curl_pgw
+            cat << EOF | $curl_pgw
 ${cpuinfo}
 ${cpuclock}
 ${loadavg}
 ${meminfo}
+EOF
+            last_load_report=$now
+        fi
+
+        mcount=$(ls -1 thread-*_seq-${iter}.txt 2>/dev/null | wc -l)
+
+        # wrk2 still initialising?
+        [ $init -eq 1 ] && {
+            grep -E \
+                  '^Initialised [0-9]+ threads in [0-9]+ ms.' stats 2>/dev/null
+            if [ $? -ne 0 ] ; then
+                init_progress=$(($mcount * 100 / num_threads))
+                cat << EOF | $curl_pgw
+# TYPE wrk2_benchmark_progress counter
+wrk2_benchmark_progress{status="init"} $init_progress
+EOF
+                echo "INIT Progress: $init_progress% , ${mcount} / ${num_threads} threads"
+                sleep 1
+                continue
+            else
+                init=0
+                cat << EOF | $curl_pgw
+# TYPE wrk2_benchmark_progress counter
+wrk2_benchmark_progress{status="init"} 100
+wrk2_benchmark_progress{status="run"} 0
+EOF
+                start_ts=$now
+            fi
+        }
+
+        # wait until all threads reported for this iteration
+        [ $mcount -lt $num_threads ] && {
+            sleep 0.01 # yield CPU
+            continue; }
+
+        runtime=$(($now - $start_ts))
+        progress=$(($runtime * 100 / $duration))
+        [ $progress -gt 100 ] && progress=100
+
+        # runtime info
+        cat << EOF | $curl_pgw
 # TYPE wrk2_benchmark_requests counter
 # TYPE wrk2_benchmark_responses counter
 # TYPE wrk2_benchmark_average_rps gauge
@@ -216,7 +247,8 @@ ${meminfo}
 # TYPE wrk2_benchmark_requested_rps gauge
 # TYPE wrk2_benchmark_thread_count counter
 # TYPE wrk2_benchmark_duration counter
-wrk2_benchmark_progress $progress
+wrk2_benchmark_progress{status="init"} 100
+wrk2_benchmark_progress{status="run"} $progress
 wrk2_benchmark_requested_rps $req_rps
 wrk2_benchmark_thread_count $num_threads
 wrk2_benchmark_duration $duration
@@ -230,7 +262,7 @@ $(cat thread-*_seq-${iter}.txt | grep 'wrk2_benchmark_run_')
 $(echo "$loadavg" | sed 's/wrk2_benchmark_node_/wrk2_benchmark_run_node_/')
 EOF
 
-        echo "Progress: $progress% , ${runtime}s / ${duration}s"
+        echo "RUN Progress: $progress% , ${runtime}s / ${duration}s"
         rm thread-*_seq-${iter}.txt
         iter=$(($iter+1))
     done
@@ -240,10 +272,10 @@ EOF
 
 # ---------------------
 
+start_ts=$(date +%s)
 rm -f thread-*_seq-*.txt "benchmark-end.txt"
 
-start_ts=$(date +%s)
-prometheus_pusher "$conn" "$rps" "$duration_s" "$curl_pgw" "$start_ts" &
+prometheus_pusher "$conn" "$rps" "$duration_s" "$curl_pgw" &
 
 # split off first endpoint, generate LUA include file with all endpoints
 # to spped up thread start-up when many endpoints are defined
@@ -255,6 +287,21 @@ for e in $servers; do
     count=$((count+1))
 done
 
+# wait until first endpoint becomes available.
+echo "Waiting for '$first_server' to become available"
+timeout=120
+st=$(date +%s)
+ts="$st"
+while [ $((st + timeout)) -ge $ts ]; do
+    echo "    Trying $first_server (for $((st+timeout-ts)) more seconds) ..."
+    curl -s -m 5 "$first_server" >/dev/null && break
+    ts=$(date +%s)
+    sleep 1
+done
+echo "'$first_server' responded, starting benchmark."
+echo "----"
+echo
+
 unbuffer /usr/local/bin/wrk \
               -s /usr/local/bin/multiple-endpoints-prometheus-metrics.lua \
               --lua-dont-pass-body \
@@ -263,8 +310,11 @@ unbuffer /usr/local/bin/wrk \
     | unbuffer -p tee stats
 
 > "benchmark-end.txt"
+
 sleep 2
-kill %1
+kill -9 %1
+wait
+
 echo ""
 
 # ---------------------
@@ -322,7 +372,9 @@ wrk2_benchmark_run_runtime{kind="start"} $start_ts
 wrk2_benchmark_run_runtime{kind="end"} $end_ts
 wrk2_benchmark_run_runtime{kind="duration"} $duration_s
 # TYPE wrk2_benchmark_progress counter
-wrk2_benchmark_progress 100
+wrk2_benchmark_progress{status="init"} 100
+wrk2_benchmark_progress{status="run"} 100
+wrk2_benchmark_progress{status="done"} 100
 EOF
 
 # send final wrk2 stats
@@ -437,8 +489,4 @@ awk '
     ' stats \
  | $curl_pgw
 
-cat << EOF | $curl_pgw
-# TYPE wrk2_benchmark_progress counter
-wrk2_benchmark_progress 100
-EOF
 

--- a/docker/prometheus-export-wrapper
+++ b/docker/prometheus-export-wrapper
@@ -27,6 +27,7 @@ usage() {
     echo " -d <duration> - Test duration in seconds. Default: $dur"
     echo " -p <push-gateway> - URL of prometheus push gateway. Default: $pgw"
     echo "                     Use 'stdout' to just print to standard output."
+    echo "                     Use 'null' to suppress output (for debugging)."
     echo
 }
 
@@ -54,6 +55,8 @@ done
 # set up CURL command to push to Prometheus
 if [ "$pgw" = "stdout" ] ; then
     curl_pgw="cat -"
+elif [ "$pgw" = "null" ] ; then 
+    curl_pgw="true"
 else
     # check if gateway is available
     curl_pgw="curl -s --data-binary @- $pgw"
@@ -88,6 +91,11 @@ echo "   servers: $servers"
 echo
 
 sleep 1
+
+# we use files to exchange per-thread matrics; use ram-backed fs for this file
+# I/O to prevent threads being stuck in IOWAIT
+cd /tmpfs
+
 
 # ---------------------
 
@@ -166,23 +174,30 @@ prometheus_pusher() {
     local threads=$(get_cpuinfo | grep '{info="threads"}' | sed 's/.*} //')
     local cores=$(get_cpuinfo | grep '{info="cores"}' | sed 's/.*} //')
 
+    local cpuclock=$(get_cpuclock)
+    local loadavg=$(get_loadavg "$cores" "$threads")
+    local meminfo=$(get_meminfo)
+
     local iter=0
 
     while [ ! -f "benchmark-end.txt" ] ; do
-        sleep 0.5
-        mcount=$(ls -1 | grep -cE "^thread-[0-9]+_seq-${iter}.txt")
+        mcount=$(ls -1 thread-*_seq-${iter}.txt 2>/dev/null | wc -l)
 
-        [ $mcount -lt $num_threads ] && continue
-
-        local cpuclock=$(get_cpuclock)
-        local loadavg=$(get_loadavg "$cores" "$threads")
-        local meminfo=$(get_meminfo)
+        [ $mcount -lt $num_threads ] && {
+            sleep 0.01 # yield CPU
+            continue; }
 
         now=$(date +%s)
         runtime=$(($now - $start_ts))
         progress=$(($runtime * 100 / $duration))
         [ $progress -gt 100 ] && progress=100
 
+        # update every 10s
+        if [ $((runtime % 10)) -eq 0 ] ; then
+            cpuclock=$(get_cpuclock)
+            loadavg=$(get_loadavg "$cores" "$threads")
+            meminfo=$(get_meminfo)
+        fi
 
         # runtime info
         cat << EOF | $curl_pgw
@@ -205,13 +220,13 @@ wrk2_benchmark_progress $progress
 wrk2_benchmark_requested_rps $req_rps
 wrk2_benchmark_thread_count $num_threads
 wrk2_benchmark_duration $duration
-$(grep -h -vE '^wrk2_benchmark_run_' thread-*_seq-${iter}.txt)
+$(cat thread-*_seq-${iter}.txt | grep -v 'wrk2_benchmark_run_')
 EOF
 
         # Results info, pushed after run concluded
         cat << EOF > wrk2_benchmark_run.txt
 # TYPE wrk2_benchmark_run_average_tcp_reconnect_rate gauge
-$(grep -h -E '^wrk2_benchmark_run_' thread-*_seq-${iter}.txt)
+$(cat thread-*_seq-${iter}.txt | grep 'wrk2_benchmark_run_')
 $(echo "$loadavg" | sed 's/wrk2_benchmark_node_/wrk2_benchmark_run_node_/')
 EOF
 

--- a/src/script.c
+++ b/src/script.c
@@ -194,6 +194,10 @@ bool script_has_done(lua_State *L) {
     return script_is_function(L, "done");
 }
 
+bool script_has_teardown(lua_State *L) {
+    return script_is_function(L, "teardown");
+}
+
 void script_header_done(lua_State *L, luaL_Buffer *buffer) {
     luaL_pushresult(buffer);
 }
@@ -228,6 +232,11 @@ void script_errors(lua_State *L, errors *errors) {
     lua_newtable(L);
     set_fields(L, 2, fields);
     lua_setfield(L, 1, "errors");
+}
+
+void script_teardown(lua_State *L) {
+    lua_getglobal(L, "teardown");
+    lua_call(L, 0, 0);
 }
 
 void script_done(lua_State *L, stats *latency, stats *requests) {

--- a/src/script.c
+++ b/src/script.c
@@ -514,6 +514,12 @@ void script_copy_value(lua_State *src, lua_State *dst, int index) {
             }
             lua_pop(src, 1);
             break;
+        case LUA_TUSERDATA:
+            {
+                struct addrinfo *src_addr = checkaddr(src);
+                script_addr_clone(dst, src_addr);
+            }
+            break;
         default:
             luaL_error(src, "cannot transfer '%s' to thread", luaL_typename(src, index));
     }

--- a/src/script.h
+++ b/src/script.h
@@ -18,10 +18,12 @@ void script_done(lua_State *, stats *, stats *);
 void script_init(lua_State *, thread *, int, char **);
 void script_request(lua_State *, char **, size_t *);
 void script_response(lua_State *, int, buffer *, buffer *);
+void script_teardown(lua_State *);
 size_t script_verify_request(lua_State *L);
 
 bool script_is_static(lua_State *);
 bool script_want_response(lua_State *L);
+bool script_has_teardown(lua_State *L);
 bool script_has_done(lua_State *L);
 void script_summary(lua_State *, uint64_t, uint64_t, uint64_t);
 void script_errors(lua_State *, errors *);

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -201,6 +201,10 @@ int main(int argc, char **argv) {
 
         hdr_add(latency_histogram, t->latency_histogram);
         hdr_add(u_latency_histogram, t->u_latency_histogram);
+
+        if (script_has_teardown(t->L)) {
+            script_teardown(t->L);
+        }
     }
 
     long double runtime_s   = runtime_us / 1000000.0;


### PR DESCRIPTION
This change introduces a `teardown()` LUA callback which is called after a run concluded, in a per-thread context. The rationale of this callback is to allow threads to clean up / finish work, e.g. concluding per-thread statistics.

The `multiple-endpoints-prometheus-metrics.lua` script uses the new callback to improve per-thread statistics reporting.

Also, `wrk.c` now first initialises all threads (including LUA contexts and `setup()` and `init()` callbacks) before starting the first thread. The prometheus wrapper script now reports progress of thread initialisation and benchmark run progress separately.

Finally, `script.c` has been extended to allow passing of `wrk.addr` userdata objects across LUA contexts. This allows us to initialise all endpoints once, in `setup()`, instead of once per thread, in the threads' `init()` callback. This significantly speeds up initialisation with large numbers of threads / endpoints.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>