### PR TITLE
use float for prometheus metrics

### DIFF
--- a/scripts/multiple-endpoints-prometheus-metrics.lua
+++ b/scripts/multiple-endpoints-prometheus-metrics.lua
@@ -118,7 +118,7 @@ end
 
 function prom(mname, value)
     return string.format(
-                   "wrk2_benchmark_%s{thread=\"thread-%s\"} %d\n",mname,id,value)
+                   "wrk2_benchmark_%s{thread=\"thread-%s\"} %f\n",mname,id,value)
 end
 
 function busysleep(microseconds)


### PR DESCRIPTION
One-line change: use float for reporting metrics values. Using integers cuts off everything after the decimal point, leading to lower than actual RPS being reported.