### PR TITLE
prometheus wrapper: add init delay

### DIFF
--- a/docker/prometheus-export-wrapper
+++ b/docker/prometheus-export-wrapper
@@ -7,6 +7,7 @@
 conn=10
 rps=10
 dur=60
+init_delay=0
 pgw="http://pushgateway.monitoring:9091/metrics/job/wrk2_benchmark/instance/test_run"
 
 usage() {
@@ -25,6 +26,8 @@ usage() {
     echo " -c <connections> - Number of concurrent connections. Default: $conn"
     echo " -r <rps> - Target rate of requests per second. Default: $rps"
     echo " -d <duration> - Test duration in seconds. Default: $dur"
+    echo " -i <duration> - Initial delay (sleep time before start) in seconds"
+    echo "                 Default: $init_delay"
     echo " -p <push-gateway> - URL of prometheus push gateway. Default: $pgw"
     echo "                     Use 'stdout' to just print to standard output."
     echo "                     Use 'null' to suppress output (for debugging)."
@@ -46,11 +49,18 @@ for arg do
     [ "$arg" = "-r" ] &&  { next="rps"; continue; }
     [ "$arg" = "-d" ] &&  { next="dur"; continue; }
     [ "$arg" = "-p" ] &&  { next="pgw"; continue; }
+    [ "$arg" = "-i" ] &&  { next="init_delay"; continue; }
 
     [ -n "$next" ] && { eval $next="$arg"; next=""; continue; }
 
     servers="$servers $arg"
 done
+
+[ $init_delay -ne 0 ] && {
+    echo "Init delay: sleeping for $init_delay seconds."
+    sleep "$init_delay"
+    echo "Slept well, now starting benchmark"
+}
 
 # set up CURL command to push to Prometheus
 if [ "$pgw" = "stdout" ] ; then


### PR DESCRIPTION
This PR adds a new `-i <seconds>` init delay to the prometheus wrapper, allowing for an optional sleep time before the benchmark starts.