### PR TITLE
fix connection error message

### DIFF
--- a/scripts/multiple-endpoints-prometheus-metrics.lua
+++ b/scripts/multiple-endpoints-prometheus-metrics.lua
@@ -80,7 +80,7 @@ function setup(thread)
                     if not addr then
                         print(string.format(
                             "Thread %d Error: Failed to connect to %s:%d",
-                            id, host, port))
+                            counter, host, port))
                         os.exit(2)
                     end
             end


### PR DESCRIPTION
The `setup()` function in multiple-endpoints-prometheus-metrics.lua had an error `printf` which used a nonexistent variable. This PR fixes that. 