### PR TITLE
ARM support for wrk2, Prometheus docker image

### DIFF
--- a/docker/Dockerfile.benchmark-container-prometheus-export
+++ b/docker/Dockerfile.benchmark-container-prometheus-export
@@ -1,4 +1,8 @@
-FROM alpine as builder
+# Leave empty for x86, set to e.g. "arm64v8/" (note closing slash!) for ARM, e,g, 
+# $ docker build --build-arg ARCH="arm64v8/" -t wrk2-arm -f docker/Dockerfile.benchmark-container-prometheus-export .
+ARG ARCH=""
+
+FROM ${ARCH}alpine as builder
 MAINTAINER Kinvolk
 
 WORKDIR /usr/src
@@ -12,7 +16,7 @@ RUN cd wrk2-cache-stresser && \
 
 
 
-FROM alpine
+FROM ${ARCH}alpine
 MAINTAINER Kinvolk
 
 RUN apk add --update --no-cache expect curl util-linux \

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,6 +18,22 @@ e.g.
 $ docker build -t cache-stresser -f docker/Dockerfile.cache-stresser .
 ```
 
+## wrk2 with Prometheus stats export
+
+A tiny Docker image based on Alpine which can export both run-time metrics (current RPS, resource usage) and result metrics (overall RPS, latency histogramm).  The container image wraps `wrk2` into `prometheus-export-wrapper`, emitting metrics to a prometheus [push-gateway](https://github.com/prometheus/pushgateway).
+The image can be built for (at least) both x86_64 (the default) and ARM64.
+
+For x86 simply use
+```shell
+$ docker build -t wrk2 -f docker/Dockerfile.benchmark-container-prometheus-export .
+```
+
+and for ARM64 use
+```shell
+$ docker build --build-arg ARCH="arm64v8/" -t wrk2-arm -f docker/Dockerfile.benchmark-container-prometheus-export .
+```
+
+
 ## Cache-stresser
 A tiny Docker image based on Alpine for stressing CDN / cache servers.
 

--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>
+#ifdef __x86_64__
 #include <x86intrin.h>
+#endif
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
# ARM support for wrk2, Prometheus docker image

This PR enables ARM support for wrk2 and for the Promentheus push-gateway docker image. 

In wrk2's src/hdr_histogram.c, the X86intrinsics header file is only included on x86 now - which fixes an issue with compiling wrk2 on ARM.
Also, an ARCH variable has been added to the prometheus pushgateway exporter docker image so the image can be built for ARM and x86.

# How to use

See elaborated section in this PR's [docker/README.md](https://github.com/kinvolk/wrk2/blob/0ec1aa4f6fc17962ea8aab9d0b73298972718958/docker/README.md#wrk2-with-prometheus-stats-export).

# Testing done

Built +  ran Prometheus exporter docker image for both ARM and X86 (ARM using qemu).
