### PR TITLE
usage of correct type (int) for rate variable

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -743,7 +743,7 @@ static struct option longopts[] = {
 };
 
 static int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
-    unsigned int c;
+    int c;
     char **header = headers;
 
     memset(cfg, 0, sizeof(struct config));

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -743,7 +743,8 @@ static struct option longopts[] = {
 };
 
 static int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
-    char c, **header = headers;
+    unsigned int c;
+    char **header = headers;
 
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;


### PR DESCRIPTION
# The rate variable needs to be an int.

The rate variable was declared as "char". But it needs to be an int. This PR changes it.

## Standard build and run.

Builds and works out-of-the-box.
